### PR TITLE
Do not install python* commands from pypy 

### DIFF
--- a/test-tier3/run
+++ b/test-tier3/run
@@ -3,4 +3,4 @@ mkdir /judge
 cd /judge || exit
 curl -L https://github.com/DMOJ/judge/archive/master.tar.gz | tar -xz --strip-components=1
 pip3 install -e .
-runuser -u judge -w PATH -- bash -c '. ~/.profile; python3 .docker.test.py'
+runuser -u judge -w PATH -- bash -c '. ~/.profile; python3 -u .docker.test.py'

--- a/tier2/Dockerfile
+++ b/tier2/Dockerfile
@@ -13,8 +13,10 @@ RUN apt-get update && \
     ) && \
     mkdir /opt/pypy2 && curl -L "$(curl https://www.pypy.org/download.html | grep /pypy2 | head -n1 | cut -d'"' -f4)" | \
         tar xj -C /opt/pypy2 --strip-components=1 && /opt/pypy2/bin/pypy -mcompileall && \
+    rm -f /opt/pypy2/bin/python* && \
     mkdir /opt/pypy3 && curl -L "$(curl https://www.pypy.org/download.html | grep /pypy3 | head -n1 | cut -d'"' -f4)" | \
         tar xj -C /opt/pypy3 --strip-components=1 && /opt/pypy3/bin/pypy -mcompileall && \
+    rm -f /opt/pypy3/bin/python* && \
     runuser judge -c 'curl https://sh.rustup.rs -sSf | sh -s -- -y' && \
         mkdir rust && ( \
             cd rust && \


### PR DESCRIPTION
This avoids pypy taking over the `python3` command and making the test run under pypy.

Also unbuffered `.docker.test.py` to be more readable.