### PR TITLE
Add arm64 docker build job

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -63,11 +63,16 @@ jobs:
       run: make TAG=aarch64-latest image-tier1
     - name: Test tier 1 Docker image
       run: make TAG=aarch64-latest test-tier1
+    - name: Build tier 2 Docker image
+      run: make TAG=aarch64-latest image-tier2
+    - name: Test tier 2 Docker image
+      run: make TAG=aarch64-latest test-tier2
     - name: Push images to Docker
       if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/master'
       run: |
         echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
         docker push dmoj/runtimes-tier1:aarch64-latest
+        docker push dmoj/runtimes-tier2:aarch64-latest
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
@@ -76,6 +81,7 @@ jobs:
       run: |
         echo "$CR_PAT" | docker login ghcr.io -u "$CR_USER" --password-stdin
         docker push ghcr.io/dmoj/runtimes-tier1:aarch64-latest
+        docker push ghcr.io/dmoj/runtimes-tier2:aarch64-latest
       env:
         CR_USER: ${{ secrets.CR_USER }}
         CR_PAT: ${{ secrets.CR_PAT }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,12 +67,17 @@ jobs:
       run: make TAG=aarch64-latest image-tier2
     - name: Test tier 2 Docker image
       run: make TAG=aarch64-latest test-tier2
+    - name: Build tier 3 Docker image
+      run: make TAG=aarch64-latest image-tier3
+    - name: Test tier 3 Docker image
+      run: make TAG=aarch64-latest test-tier3
     - name: Push images to Docker
       if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/master'
       run: |
         echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
         docker push dmoj/runtimes-tier1:aarch64-latest
         docker push dmoj/runtimes-tier2:aarch64-latest
+        docker push dmoj/runtimes-tier3:aarch64-latest
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
@@ -82,6 +87,7 @@ jobs:
         echo "$CR_PAT" | docker login ghcr.io -u "$CR_USER" --password-stdin
         docker push ghcr.io/dmoj/runtimes-tier1:aarch64-latest
         docker push ghcr.io/dmoj/runtimes-tier2:aarch64-latest
+        docker push ghcr.io/dmoj/runtimes-tier3:aarch64-latest
       env:
         CR_USER: ${{ secrets.CR_USER }}
         CR_PAT: ${{ secrets.CR_PAT }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,9 @@ on:
   schedule:
     - cron: '0 0 * * 1'
 jobs:
-  build:
+  amd64:
+    permissions:
+      packages: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
@@ -47,6 +49,33 @@ jobs:
         docker push ghcr.io/dmoj/runtimes-tier1:amd64-latest
         docker push ghcr.io/dmoj/runtimes-tier2:amd64-latest
         docker push ghcr.io/dmoj/runtimes-tier3:amd64-latest
+      env:
+        CR_USER: ${{ secrets.CR_USER }}
+        CR_PAT: ${{ secrets.CR_PAT }}
+
+  arm64:
+    permissions:
+      packages: write
+    runs-on: [self-hosted, Linux, ARM64]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build tier 1 Docker image
+      run: make TAG=aarch64-latest image-tier1
+    - name: Test tier 1 Docker image
+      run: make TAG=aarch64-latest test-tier1
+    - name: Push images to Docker
+      if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/master'
+      run: |
+        echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
+        docker push dmoj/runtimes-tier1:aarch64-latest
+      env:
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+    - name: Push images to GitHub Containers
+      if: (github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/master'
+      run: |
+        echo "$CR_PAT" | docker login ghcr.io -u "$CR_USER" --password-stdin
+        docker push ghcr.io/dmoj/runtimes-tier1:aarch64-latest
       env:
         CR_USER: ${{ secrets.CR_USER }}
         CR_PAT: ${{ secrets.CR_PAT }}

--- a/tier1/Dockerfile
+++ b/tier1/Dockerfile
@@ -7,7 +7,7 @@ RUN echo deb http://deb.debian.org/debian/ stretch main > /etc/apt/sources.list.
     apt-get update && \
     apt-get install -y --no-install-recommends \
         curl file gcc g++ python3-pip python3-dev python3-setuptools python3-wheel cython3 libseccomp-dev bzip2 gzip \
-        python2 fp-compiler libxtst6 tini && \
+        python2 fp-compiler libxtst6 tini $([ "$(arch)" = aarch64 ] && echo binutils-arm-linux-gnueabihf) && \
     apt-get install -y -t stretch --no-install-recommends openjdk-8-jdk-headless openjdk-8-jre-headless && \
     apt-get install -y -t experimental --no-install-recommends g++-11 && \
     rm -rf /var/lib/apt/lists/* && \

--- a/tier2/Dockerfile
+++ b/tier2/Dockerfile
@@ -3,7 +3,7 @@ FROM dmoj/runtimes-tier1
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         jq apt-transport-https dirmngr gnupg ca-certificates \
-        openjdk-17-jdk-headless clang ghc golang racket ruby scala nasm libc6-dev-i386 && \
+        openjdk-17-jdk-headless clang ghc golang racket ruby scala nasm $([ "$(arch)" = x86_64 ] && echo libc6-dev-i386) && \
     ( \
         apt-get install -y --no-install-recommends make m4 patch unzip libgmp-dev && \
         bash -c 'echo | sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) --no-backup' && \
@@ -11,10 +11,11 @@ RUN apt-get update && \
         runuser -u judge -- opam install -y -j$(nproc) base core stdio zarith && \
         runuser -u judge -- opam clean && rm -rf ~judge/.opam/repo \
     ) && \
-    mkdir /opt/pypy2 && curl -L "$(curl https://www.pypy.org/download.html | grep /pypy2 | head -n1 | cut -d'"' -f4)" | \
+    if [ "$(arch)" = x86_64 ]; then PYPY_ARCH=linux64; else PYPY_ARCH="$(arch)"; fi && \
+    mkdir /opt/pypy2 && curl -L "$(curl https://www.pypy.org/download.html | grep "/pypy2.*$PYPY_ARCH" | head -n1 | cut -d'"' -f4)" | \
         tar xj -C /opt/pypy2 --strip-components=1 && /opt/pypy2/bin/pypy -mcompileall && \
     rm -f /opt/pypy2/bin/python* && \
-    mkdir /opt/pypy3 && curl -L "$(curl https://www.pypy.org/download.html | grep /pypy3 | head -n1 | cut -d'"' -f4)" | \
+    mkdir /opt/pypy3 && curl -L "$(curl https://www.pypy.org/download.html | grep "/pypy3.*$PYPY_ARCH" | head -n1 | cut -d'"' -f4)" | \
         tar xj -C /opt/pypy3 --strip-components=1 && /opt/pypy3/bin/pypy -mcompileall && \
     rm -f /opt/pypy3/bin/python* && \
     runuser judge -c 'curl https://sh.rustup.rs -sSf | sh -s -- -y' && \
@@ -31,13 +32,13 @@ RUN apt-get update && \
             runuser -u judge /home/judge/.cargo/bin/cargo fetch \
         ) && \
         rm -rf rust && \
-    curl -L -odmd.deb "$(curl -s https://dlang.org/download.html | perl -ne 'if(/"([^"~]*_amd64.deb)/){print $1;exit}')" && \
-        apt install ./dmd.deb && rm dmd.deb && \
+    if [ "$(arch)" = x86_64 ]; then curl -L -odmd.deb "$(curl -s https://dlang.org/download.html | perl -ne 'if(/"([^"~]*_amd64.deb)/){print $1;exit}')" && \
+        apt install ./dmd.deb && rm dmd.deb; fi && \
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
     echo "deb https://download.mono-project.com/repo/debian stable-buster main" > \
         /etc/apt/sources.list.d/mono-official-stable.list && \
     curl https://dmoj.ca/dmoj-apt.key | apt-key add - && \
-    echo 'deb [arch=amd64] https://apt.dmoj.ca/ stretch main non-free' > /etc/apt/sources.list.d/dmoj.list && \
+    echo 'deb https://apt.dmoj.ca/ bullseye main' > /etc/apt/sources.list.d/dmoj.list && \
     (echo 'Package: *'; echo 'Pin: origin download.mono-project.com'; echo 'Pin-Priority: 990') > /etc/apt/preferences.d/mono && \
     apt-get update && \
     (cd /tmp && \

--- a/tier3/Dockerfile
+++ b/tier3/Dockerfile
@@ -1,14 +1,19 @@
 FROM dmoj/runtimes-tier2
 
-RUN curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
-    echo 'deb [arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' > /etc/apt/sources.list.d/dart.list && \
+RUN (cd /opt && \
+        case "$(arch)" in x86_64) DART_ARCH=x64;; aarch64) DART_ARCH=arm64;; *) false;; esac && \
+        curl -L -odart.zip "https://storage.googleapis.com/dart-archive/channels/stable/release/$( \
+            curl -sSL https://storage.googleapis.com/dart-archive/channels/stable/release/latest/VERSION | jq -r .version \
+        )/sdk/dartsdk-linux-$DART_ARCH-release.zip" && \
+        unzip dart.zip && find /opt/dart-sdk -type d -exec chmod go+rx {} + && rm dart.zip) && \
     apt-get update && \
     apt-get install -y --no-install-recommends unzip libtinfo5 xz-utils \
-        coffeescript gnucobol4 gnat gfortran tcl lua5.3 intercal php-cli dart/stable gforth swi-prolog pike8.0 sbcl && \
+        coffeescript gnucobol4 gnat gfortran tcl lua5.3 intercal php-cli gforth swi-prolog pike8.0 sbcl && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir /opt/swift && \
-    curl "$(echo -n https://swift.org; curl -s https://swift.org/download/ | grep 'Ubuntu 18.04' | grep 5.4 | head -n 1 | cut -d'"' -f 2)" | \
-        tar xz -C /opt/swift --strip-components=1 && \
+    if [ "$(arch)" = x86_64 ]; then \
+        curl "https://swift.org$(curl -s https://swift.org/download/ | grep 'Ubuntu 18.04' | grep 5.4 | head -n 1 | cut -d'"' -f 2)" | \
+            tar xz -C /opt/swift --strip-components=1; fi && \
     curl -L -ogroovy.zip "$(curl -s https://groovy.apache.org/download.html | perl -ne 'if(/(['"'"'"])(https:[^'"'"'"]+-binary-[\d.]+\.zip)\1/){print$2;exit}')" && \
         unzip groovy.zip && \
         mkdir /opt/groovy && \
@@ -17,9 +22,10 @@ RUN curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - &
     curl -L -okotlin.zip "$(curl -s https://api.github.com/repos/JetBrains/kotlin/releases | \
             jq -r '[.[] | select(.prerelease | not) | .assets | flatten | .[] | select(.name | startswith("kotlin-compiler")) | .browser_download_url][0]')" && \
         unzip kotlin.zip && mv kotlinc /opt/kotlin && rm kotlin.zip && \
-    curl -L -otprolog.zip "https://github.com/yingted/OpenTuring/releases/download/v1.0.0-beta/tprolog-v1.0.0-beta.zip" && \
-        unzip tprolog.zip && mv tprolog /opt && rm tprolog.zip && \
+    if [ "$(arch)" = x86_64 ]; then \
+        curl -L -otprolog.zip "https://github.com/yingted/OpenTuring/releases/download/v1.0.0-beta/tprolog-v1.0.0-beta.zip" && \
+            unzip tprolog.zip && mv tprolog /opt && rm tprolog.zip; fi && \
     mkdir /opt/zig && \
-        curl "https://ziglang.org/download/0.6.0/zig-linux-x86_64-0.6.0.tar.xz" | tar xJ -C /opt/zig  --strip-components=1
+        curl "https://ziglang.org/download/0.6.0/zig-linux-$(arch)-0.6.0.tar.xz" | tar xJ -C /opt/zig --strip-components=1
 
-ENV PATH "/opt/tprolog:/opt/groovy/bin:/opt/kotlin/bin:${PATH}:/opt/swift/usr/bin:/opt/zig"
+ENV PATH "/opt/tprolog:/opt/groovy/bin:/opt/kotlin/bin:/opt/dart-sdk/bin:${PATH}:/opt/swift/usr/bin:/opt/zig"


### PR DESCRIPTION
Executors that we can't use on arm64:
* D: `dmd` is x86 and amd64 only
* GAS32, GAS64, NASM, NASM64: not compatible with CPU
* SWIFT: not supported by current release, but will be supported later
* TUR: `tprolog` is x86 only

The following judge pull requests are needed for tests to pass:

* DMOJ/judge-server#943
* DMOJ/judge-server#944
* DMOJ/judge-server#945
* DMOJ/judge-server#946