### PR TITLE
Install ca-certificates-java from sid

### DIFF
--- a/tier1/Dockerfile
+++ b/tier1/Dockerfile
@@ -7,7 +7,7 @@ RUN echo deb http://deb.debian.org/debian/ stretch main > /etc/apt/sources.list.
     apt-get update && \
     apt-get install -y --no-install-recommends \
         curl file gcc g++ python3-pip python3-dev python3-setuptools python3-wheel cython3 libseccomp-dev bzip2 gzip \
-        python2 fp-compiler libxtst6 tini && \
+        python2 fp-compiler libxtst6 tini ca-certificates-java && \
     apt-get install -y -t stretch --no-install-recommends openjdk-8-jdk-headless openjdk-8-jre-headless && \
     apt-get install -y -t experimental --no-install-recommends g++-11 && \
     rm -rf /var/lib/apt/lists/* && \


### PR DESCRIPTION
Due to the `-t stretch` line pulling `ca-certificates-java`, the very old stretch version is installed instead of the sid version, causing chaos down the line when it tries to convert the certificate format.

To solve this, we install it explicitly before the `-t stretch` installation of openjdk-8.