### PR TITLE
Install libncurses5 for Swift

### DIFF
--- a/tier3/Dockerfile
+++ b/tier3/Dockerfile
@@ -3,7 +3,7 @@ FROM dmoj/runtimes-tier2
 RUN curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
     echo 'deb [arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' > /etc/apt/sources.list.d/dart.list && \
     apt-get update && \
-    apt-get install -y --no-install-recommends unzip libtinfo5 xz-utils \
+    apt-get install -y --no-install-recommends unzip libtinfo5 xz-utils libncurses5 \
         coffeescript gnucobol4 gnat gfortran tcl lua5.3 intercal php-cli dart/stable gforth swi-prolog pike8.0 sbcl && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir /opt/swift && \


### PR DESCRIPTION
Swift requires `libncurses.so.5` as a runtime dependency.