### PR TITLE
Fix Perl by creating `/etc/perl`

### DIFF
--- a/tier1/Dockerfile
+++ b/tier1/Dockerfile
@@ -10,6 +10,7 @@ RUN echo deb http://deb.debian.org/debian/ stretch main > /etc/apt/sources.list.
         python2 fp-compiler libxtst6 tini ca-certificates-java && \
     apt-get install -y -t stretch --no-install-recommends openjdk-8-jdk-headless openjdk-8-jre-headless && \
     apt-get install -y -t experimental --no-install-recommends g++-11 && \
+    mkdir -p /etc/perl && \
     rm -rf /var/lib/apt/lists/* && \
     useradd -m judge
 


### PR DESCRIPTION
We don't add sandbox rules for directories that don't exist (to be Landlock-compatible, even though we could support them for the regular sandbox), which causes us to `EACCES` Perl's attempts to access `/etc/perl`.

Perl is tolerant of `ENOENT` here, but not `EACCES`. When it gets `EACCES`, it fails with:

```
Auto-configuring PERL:   Denied syscall access: Denying /etc/ld.so.preload, normalized to /etc/ld.so.preload
Denied syscall fstatat: Denying /etc/perl/re.pmc, normalized to /etc/perl/re.pmc
Denied syscall fstatat: Denying /etc/perl/re.pm, normalized to /etc/perl/re.pm
Can't locate re.pm:   /etc/perl/re.pm: Permission denied.
BEGIN failed--compilation aborted.
Failed self-test
  Attempted:
    perl: /usr/bin/perl
  Errors:
    Got unexpected stdout output:
```

Let's just give it an empty directory to work with.