### PR TITLE
Don't pull `Cargo.lock` from `RUST.py`.

### DIFF
--- a/tier2/Dockerfile
+++ b/tier2/Dockerfile
@@ -25,8 +25,6 @@ RUN apt-get update && \
             cd rust && \
             curl -sL https://raw.githubusercontent.com/DMOJ/judge/master/dmoj/executors/RUST.py | \
                 sed '/^CARGO_TOML/,/^"""/!d;//d' > Cargo.toml && \
-            curl -sL https://raw.githubusercontent.com/DMOJ/judge/master/dmoj/executors/RUST.py | \
-                sed '/^CARGO_LOCK/,/^"""/!d;//d' > Cargo.lock && \
             mkdir src && \
             curl -sL https://raw.githubusercontent.com/DMOJ/judge/master/dmoj/executors/RUST.py | \
                 sed '/^HELLO_WORLD_PROGRAM/,/^"""/!d;//d' > src/main.rs && \


### PR DESCRIPTION
We don't need it, our TOML is plenty.

In particular, modern `.lock` files are supposed to be generated and not edited. We should do the same.