### PR TITLE
Rust program upgrade

### DIFF
--- a/tier2/Dockerfile
+++ b/tier2/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && \
                 sed '/^CARGO_TOML/,/^"""/!d;//d' > Cargo.toml && \
             mkdir src && \
             curl -sL https://raw.githubusercontent.com/DMOJ/judge/master/dmoj/executors/RUST.py | \
-                sed '/^HELLO_WORLD_PROGRAM/,/^"""/!d;//d' > src/main.rs && \
+                sed '/^TEST_PROGRAM/,/^"""/!d;//d' > src/main.rs && \
             chown -R judge: . && \
             runuser -u judge /home/judge/.cargo/bin/cargo fetch \
         ) && \


### PR DESCRIPTION
Upgrade the test program variable in docker.

Companion of DMOJ/judge-server#1066. Will fail in CI, since we no longer use the correct variable name (at least, until the companion branch is merged).

Based on #55.