### PR TITLE
Rust env updates

### DIFF
--- a/tier2/Dockerfile
+++ b/tier2/Dockerfile
@@ -53,4 +53,4 @@ RUN apt-get update && \
         rm -f *.deb) && \
     rm -rf /var/lib/apt/lists/*
 
-ENV PATH="/home/judge/.cargo/bin:/opt/pypy2/bin:/opt/pypy3/bin:/opt/dart-sdk/bin:${PATH}" DMOJ_CARGO_OFFLINE="1"
+ENV PATH="/home/judge/.cargo/bin:/opt/pypy2/bin:/opt/pypy3/bin:/opt/dart-sdk/bin:${PATH}"


### PR DESCRIPTION
Companion to https://github.com/DMOJ/judge-server/pull/1079 and https://github.com/DMOJ/judge-server/pull/1077.

Must not be merged until those PRs are merged. Removing the offline variable will break things, but adding the shared target variable will at worst have no effect.