### PR TITLE
Install only g++12, not g++11

### DIFF
--- a/tier1/Dockerfile
+++ b/tier1/Dockerfile
@@ -9,7 +9,6 @@ RUN echo deb http://deb.debian.org/debian/ stretch main > /etc/apt/sources.list.
         curl file gcc g++ python3-pip python3-dev python3-setuptools python3-wheel cython3 libseccomp-dev bzip2 gzip \
         python2 fp-compiler libxtst6 tini ca-certificates-java $([ "$(arch)" = aarch64 ] && echo binutils-arm-linux-gnueabihf) && \
     apt-get install -y -t stretch --no-install-recommends openjdk-8-jdk-headless openjdk-8-jre-headless && \
-    apt-get install -y -t experimental --no-install-recommends g++-11 && \
     mkdir -p /etc/perl && \
     rm -rf /var/lib/apt/lists/* && \
     useradd -m judge


### PR DESCRIPTION
This should prevent CPP20 from using GCC 11 instead of GCC 12 like all the other CPP executors.