### PR TITLE
Fix downloading Kotlin

### DIFF
--- a/tier3/Dockerfile
+++ b/tier3/Dockerfile
@@ -20,7 +20,7 @@ RUN (cd /opt && \
         mv groovy-*/* /opt/groovy && \
         rm -rf groovy.zip groovy-* && \
     curl -L -okotlin.zip "$(curl -s https://api.github.com/repos/JetBrains/kotlin/releases | \
-            jq -r '[.[] | select(.prerelease | not) | .assets | flatten | .[] | select(.name | startswith("kotlin-compiler")) | .browser_download_url][0]')" && \
+            jq -r '[.[] | select(.prerelease | not) | .assets | flatten | .[] | select((.name | startswith("kotlin-compiler")) and (.name | endswith(".zip"))) | .browser_download_url][0]')" && \
         unzip kotlin.zip && mv kotlinc /opt/kotlin && rm kotlin.zip && \
     if [ "$(arch)" = x86_64 ]; then \
         curl -L -otprolog.zip "https://github.com/yingted/OpenTuring/releases/download/v1.0.0-beta/tprolog-v1.0.0-beta.zip" && \


### PR DESCRIPTION
A new file was added in Kotlin 1.9.0: `kotlin-compiler-1.9.0.spdx.json`.

It causes tier 3 to fail to build since that file is downloaded instead of the correct file, `kotlin-compiler-1.9.0.zip`

<img width="674" alt="image" src="https://github.com/DMOJ/runtimes-docker/assets/17219541/787e9144-6a9e-4cbf-aa37-7b410b814780">

I fix it by adding `endswith(".zip")` to jq.
