### PR TITLE
Update Dockerfile to install Node.js to tier3 runtime image

### DIFF
--- a/tier3/Dockerfile
+++ b/tier3/Dockerfile
@@ -6,9 +6,11 @@ RUN (cd /opt && \
             curl -sSL https://storage.googleapis.com/dart-archive/channels/stable/release/latest/VERSION | jq -r .version \
         )/sdk/dartsdk-linux-$DART_ARCH-release.zip" && \
         unzip dart.zip && find /opt/dart-sdk -type d -exec chmod go+rx {} + && rm dart.zip) && \
+    { curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg; } && \
+    { echo 'deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main' > /etc/apt/sources.list.d/nodesource.list; } && \
     apt-get update && \
     apt-get install -y --no-install-recommends unzip libtinfo5 xz-utils libncurses5 \
-        gnucobol4 gnat gfortran tcl lua5.3 intercal php-cli gforth swi-prolog pike8.0 sbcl gnustep-devel && \
+        gnucobol4 gnat gfortran tcl lua5.3 intercal php-cli gforth swi-prolog pike8.0 sbcl gnustep-devel nodejs && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir /opt/swift && \
     if [ "$(arch)" = x86_64 ]; then \


### PR DESCRIPTION
### Motivation

Related to https://github.com/DMOJ/judge-server/pull/1143:

After enabling support in judge-server for a Node.js-based executor, we need to install the pre-requisites in the Docker image used for the judge.

### Changes

- Install the latest version of Node.js on Debian using Nodesource repositories

### Testing

Build image with updated Dockerfile, and ensured that Node.js was properly installed:

```sh
# Ran this on Ubuntu, but any platform with Docker installed should work
cd runtimes-docker/tier3
sudo docker build --tag=dmoj/runtimes-tier3 .
sudo docker run --entrypoint node -it dmoj/runtimes-tier3 --version
# <-- output: v20.10.0
```