### PR TITLE
Install Objective-C

### DIFF
--- a/tier3/Dockerfile
+++ b/tier3/Dockerfile
@@ -8,7 +8,7 @@ RUN (cd /opt && \
         unzip dart.zip && find /opt/dart-sdk -type d -exec chmod go+rx {} + && rm dart.zip) && \
     apt-get update && \
     apt-get install -y --no-install-recommends unzip libtinfo5 xz-utils libncurses5 \
-        gnucobol4 gnat gfortran tcl lua5.3 intercal php-cli gforth swi-prolog pike8.0 sbcl && \
+        gnucobol4 gnat gfortran tcl lua5.3 intercal php-cli gforth swi-prolog pike8.0 sbcl gnustep-devel && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir /opt/swift && \
     if [ "$(arch)" = x86_64 ]; then \


### PR DESCRIPTION
part 2 of https://github.com/DMOJ/judge-server/pull/1158

objc needs `make`. `make` was already installed in tier 2, so there is no need to add `apt-get install make`.