### PR TITLE
Update to actions checkout v4

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       packages: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build tier 1 Docker image
         run: make TAG=amd64-latest image-tier1
       - name: Test tier 1 Docker image
@@ -56,7 +56,7 @@ jobs:
     permissions:
       packages: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build tier 1 Docker image
         run: make TAG=aarch64-latest image-tier1
       - name: Test tier 1 Docker image


### PR DESCRIPTION
fix this warning

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.