### PR TITLE
Fix errors in tier2

### DIFF
--- a/tier2/Dockerfile
+++ b/tier2/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
         $([ "$(arch)" = x86_64 ] && echo libc6-dev-i386) \
         openjdk-22-jdk-headless clang llvm ghc golang racket ruby scala nasm chicken-bin && \
     ( export OPAMYES=1 OPAMJOBS=$(($(nproc) + 2)); \
-        apt-get install -y --no-install-recommends make m4 patch unzip libgmp-dev && \
+        apt-get install -y --no-install-recommends make m4 patch unzip libgmp-dev pkg-config && \
         bash -c 'echo | sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) --no-backup' && \
         runuser -u judge -- opam init --shell-setup --disable-sandboxing --bare && \
         runuser -u judge -- opam switch create dmoj --packages=ocaml.5.0.0,ocaml-option-flambda && \
@@ -14,11 +14,11 @@ RUN apt-get update && \
         runuser -u judge -- opam clean && rm -rf ~judge/.opam/repo \
     ) && \
     if [ "$(arch)" = x86_64 ]; then PYPY_ARCH=linux64; else PYPY_ARCH="$(arch)"; fi && \
-    mkdir /opt/pypy2 && curl -L "$(curl https://www.pypy.org/download.html | grep "/pypy2.*$PYPY_ARCH" | head -n1 | cut -d'"' -f4)" | \
+    mkdir /opt/pypy2 && curl -L "$(curl https://pypy.org/download.html | grep "/pypy2.*$PYPY_ARCH" | head -n1 | cut -d'"' -f4)" | \
         tar xj -C /opt/pypy2 --strip-components=1 && /opt/pypy2/bin/pypy -mcompileall && \
         chmod a+rx /opt/pypy2/lib /opt/pypy2/lib/*.so* && \
     rm -f /opt/pypy2/bin/python* && \
-    mkdir /opt/pypy3 && curl -L "$(curl https://www.pypy.org/download.html | grep "/pypy3.*$PYPY_ARCH" | head -n1 | cut -d'"' -f4)" | \
+    mkdir /opt/pypy3 && curl -L "$(curl https://pypy.org/download.html | grep "/pypy3.*$PYPY_ARCH" | head -n1 | cut -d'"' -f4)" | \
         tar xj -C /opt/pypy3 --strip-components=1 && /opt/pypy3/bin/pypy -mcompileall && \
     rm -f /opt/pypy3/bin/python* && \
     runuser judge -c 'curl https://sh.rustup.rs -sSf | sh -s -- -y' && \
@@ -35,11 +35,12 @@ RUN apt-get update && \
         rm -rf rust && \
     if [ "$(arch)" = x86_64 ]; then curl -fsS https://dlang.org/install.sh | bash -s dmd --path /opt/dlang \
         && mv /opt/dlang/dmd-*/* /opt/dlang && rmdir /opt/dlang/dmd-*; fi && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
-    echo "deb https://download.mono-project.com/repo/debian stable-buster main" > \
+    gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
+    gpg --export --armor 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF > /usr/share/keyrings/mono-official-archive-keyring.asc && \
+    echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.asc] https://download.mono-project.com/repo/debian stable-buster main" > \
         /etc/apt/sources.list.d/mono-official-stable.list && \
-    curl https://dmoj.ca/dmoj-apt.key | apt-key add - && \
-    echo 'deb https://apt.dmoj.ca/ bullseye main' > /etc/apt/sources.list.d/dmoj.list && \
+    curl https://dmoj.ca/dmoj-apt.key -o /usr/share/keyrings/dmoj-keyring.asc && \
+    echo 'deb [signed-by=/usr/share/keyrings/dmoj-keyring.asc] https://apt.dmoj.ca/ bullseye main' > /etc/apt/sources.list.d/dmoj.list && \
     (echo 'Package: *'; echo 'Pin: origin download.mono-project.com'; echo 'Pin-Priority: 990') > /etc/apt/preferences.d/mono && \
     apt-get update && \
     dpkg-divert --package mono-roslyn --divert /usr/bin/chicken-csc --rename /usr/bin/csc && \


### PR DESCRIPTION
## bugfix 1

install `pkg-config` to fix this error
```
#5 305.3 The following system packages will first need to be installed:
#5 305.3     pkg-config
#5 305.3 
#5 305.3 <><> Handling external dependencies <><><><><><><><><><><><><><><><><><><><><><>
#5 305.3 
#5 305.3 opam believes some required external dependencies are missing. opam can:
#5 305.3 > 1. Run apt-get to install them (may need root/sudo access)
#5 305.3   2. Display the recommended apt-get command and wait while you run it manually (e.g. in another terminal)
#5 305.3   3. Continue anyway, and, upon success, permanently register that this external dependency is present, but not detectable
#5 305.3   4. Abort the installation
#5 305.3 
#5 305.3 [1/2/3/4] 4
```

## bugfix 2

`curl https://www.pypy.org/download.html` gives "301 Moved Permanently", correct url is `https://pypy.org/download.html`

## bugfix 3

remove all uses of `apt-key` (it no longer exists)

i used https://www.mono-project.com/download/stable/#download-lin-debian and chatgpt to find the right commands