### PR TITLE
Clean docker images before building

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,6 +16,8 @@ jobs:
         run: echo "$GITHUB_TOKEN" | docker login ghcr.io -u $ --password-stdin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Clean Docker images
+        run: make TAG=amd64-latest clean
 
       - name: Build tier 1 Docker image
         run: make TAG=amd64-latest image-tier1
@@ -86,6 +88,8 @@ jobs:
         run: echo "$GITHUB_TOKEN" | docker login ghcr.io -u $ --password-stdin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Clean Docker images
+        run: make TAG=aarch64-latest clean
 
       - name: Build tier 1 Docker image
         run: make TAG=aarch64-latest image-tier1

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 TAG ?= latest
 
-.PHONY: all image-tier1 image-tier2 image-tier3 test-tier1 test-tier2 test-tier3
+.PHONY: all image-tier1 image-tier2 image-tier3 clean test-tier1 test-tier2 test-tier3
 
 all: image-tier1 image-tier2 image-tier3
 
@@ -8,10 +8,16 @@ image-tier1:
 	cd tier1 && docker build -t dmoj/runtimes-tier1 -t dmoj/runtimes-tier1:$(TAG) -t ghcr.io/dmoj/runtimes-tier1:$(TAG) .
 
 image-tier2: image-tier1
-	cd tier2 && docker build -t dmoj/runtimes-tier2 -t dmoj/runtimes-tier2:$(TAG) -t ghcr.io/dmoj/runtimes-tier2:$(TAG)  .
+	cd tier2 && docker build -t dmoj/runtimes-tier2 -t dmoj/runtimes-tier2:$(TAG) -t ghcr.io/dmoj/runtimes-tier2:$(TAG) .
 
 image-tier3: image-tier2
-	cd tier3 && docker build -t dmoj/runtimes-tier3 -t dmoj/runtimes-tier3:$(TAG) -t ghcr.io/dmoj/runtimes-tier3:$(TAG)  .
+	cd tier3 && docker build -t dmoj/runtimes-tier3 -t dmoj/runtimes-tier3:$(TAG) -t ghcr.io/dmoj/runtimes-tier3:$(TAG) .
+
+clean:
+	-docker rmi dmoj/runtimes-tier3 dmoj/runtimes-tier3:$(TAG) ghcr.io/dmoj/runtimes-tier3:$(TAG)
+	-docker rmi dmoj/runtimes-tier2 dmoj/runtimes-tier2:$(TAG) ghcr.io/dmoj/runtimes-tier2:$(TAG)
+	-docker rmi dmoj/runtimes-tier1 dmoj/runtimes-tier1:$(TAG) ghcr.io/dmoj/runtimes-tier1:$(TAG)
+	docker builder prune -f
 
 test: test-tier1 test-tier2 test-tier3
 

--- a/tier2/Dockerfile
+++ b/tier2/Dockerfile
@@ -4,12 +4,12 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         jq apt-transport-https dirmngr gnupg ca-certificates xz-utils \
         $([ "$(arch)" = x86_64 ] && echo libc6-dev-i386) \
-        openjdk-22-jdk-headless clang llvm ghc golang racket ruby scala nasm chicken-bin && \
+        openjdk-25-jdk-headless clang llvm ghc golang racket ruby scala nasm chicken-bin && \
     ( export OPAMYES=1 OPAMJOBS=$(($(nproc) + 2)); \
         apt-get install -y --no-install-recommends make m4 patch unzip libgmp-dev pkg-config && \
         bash -c 'echo | sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) --no-backup' && \
         runuser -u judge -- opam init --shell-setup --disable-sandboxing --bare && \
-        runuser -u judge -- opam switch create dmoj --packages=ocaml.5.0.0,ocaml-option-flambda && \
+        runuser -u judge -- opam switch create dmoj --packages=ocaml.5.4.1,ocaml-option-flambda && \
         runuser -u judge -- opam install base core stdio zarith && \
         runuser -u judge -- opam clean && rm -rf ~judge/.opam/repo \
     ) && \
@@ -37,9 +37,10 @@ RUN apt-get update && \
         && mv /opt/dlang/dmd-*/* /opt/dlang && rmdir /opt/dlang/dmd-*; fi && \
     gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
     gpg --export --armor 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF > /usr/share/keyrings/mono-official-archive-keyring.asc && \
+    sed -i 's/sha1.second_preimage_resistance.*/sha1.second_preimage_resistance = 2099-01-01/' /usr/share/apt/default-sequoia.config && \
     echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.asc] https://download.mono-project.com/repo/debian stable-buster main" > \
         /etc/apt/sources.list.d/mono-official-stable.list && \
-    curl https://dmoj.ca/dmoj-apt.key -o /usr/share/keyrings/dmoj-keyring.asc && \
+    curl https://apt.quantum2.xyz/dmoj-apt.key -o /usr/share/keyrings/dmoj-keyring.asc && \
     echo 'deb [signed-by=/usr/share/keyrings/dmoj-keyring.asc] https://apt.dmoj.ca/ bullseye main' > /etc/apt/sources.list.d/dmoj.list && \
     (echo 'Package: *'; echo 'Pin: origin download.mono-project.com'; echo 'Pin-Priority: 990') > /etc/apt/preferences.d/mono && \
     apt-get update && \


### PR DESCRIPTION
* fixes #85
* update openjdk-22 to openjdk-25
* update ocaml.5.0.0 to ocaml.5.4.1
  * error was caused by https://github.com/ocaml/ocaml/issues/14031
* extend sha1 deadline to 2099
  * see https://www.mono-project.com/download/stable/ and https://github.com/nodesource/distributions/issues/1920#issuecomment-3837165941
  * WineHQ took over mono, but let's not deal with that change in this pr
* change https://apt.dmoj.ca/dmoj-apt.key to https://apt.quantum2.xyz/dmoj-apt.key because github workers get cloudflared on the former link