### PR TITLE
Fix docker warning LegacyKeyValueFormat

### DIFF
--- a/tier3/Dockerfile
+++ b/tier3/Dockerfile
@@ -34,4 +34,4 @@ RUN (cd /opt && \
         rm -rf lean.zip lean-*; fi && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-ENV PATH "/opt/tprolog:/opt/groovy/bin:/opt/kotlin/bin:${PATH}:/opt/swift/usr/bin:/opt/zig:/opt/lean/bin"
+ENV PATH="/opt/tprolog:/opt/groovy/bin:/opt/kotlin/bin:${PATH}:/opt/swift/usr/bin:/opt/zig:/opt/lean/bin"


### PR DESCRIPTION
fix this warning
```
 1 warning found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 37)
```

this warning appeared in "Build tier 3 Docker image" since may 11