### PR TITLE
ci: clean docker better

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ clean:
 	-docker rmi dmoj/runtimes-tier3 dmoj/runtimes-tier3:$(TAG) ghcr.io/dmoj/runtimes-tier3:$(TAG)
 	-docker rmi dmoj/runtimes-tier2 dmoj/runtimes-tier2:$(TAG) ghcr.io/dmoj/runtimes-tier2:$(TAG)
 	-docker rmi dmoj/runtimes-tier1 dmoj/runtimes-tier1:$(TAG) ghcr.io/dmoj/runtimes-tier1:$(TAG)
-	docker builder prune -f
+	docker builder prune -a -f
 
 test: test-tier1 test-tier2 test-tier3
 


### PR DESCRIPTION
part 2 of #85. make sure arm64 tier 1 cache is cleared.
arm64's "Build tier 1 Docker image" took 69s, so this pr works.

update: arm64 died on "Test tier 3 Docker image" because of `Failed executors: DART, HASK, ICK, KOTLIN, NODEJS, SCALA`