### PR TITLE
tier2: fix PATH entry for Scala

### DIFF
--- a/tier2/Dockerfile
+++ b/tier2/Dockerfile
@@ -59,4 +59,4 @@ RUN apt-get update && \
         rm -f *.deb) && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-ENV PATH="/opt/dlang/linux/bin64:/home/judge/.cargo/bin:/opt/pypy2/bin:/opt/pypy3/bin:/opt/scala/:/opt/dart-sdk/bin:${PATH}"
+ENV PATH="/opt/dlang/linux/bin64:/home/judge/.cargo/bin:/opt/pypy2/bin:/opt/pypy3/bin:/opt/scala/bin:/opt/dart-sdk/bin:${PATH}"


### PR DESCRIPTION
It's quite hard to update both judge and runtimes simultaneously....