### PR TITLE
tier3: Attempt to fix Lean 4 by adding LEAN_SYSROOT and LEAN_MAIN_USE_THREAD=0

### DIFF
--- a/tier3/Dockerfile
+++ b/tier3/Dockerfile
@@ -37,3 +37,4 @@ RUN (cd /opt && \
 
 ENV PATH="/opt/tprolog:/opt/groovy/bin:/opt/kotlin/bin:${PATH}:/opt/swift/usr/bin:/opt/zig:/opt/lean/bin"
 ENV LEAN_SYSROOT="/opt/lean"
+ENV LEAN_MAIN_USE_THREAD="0"

--- a/tier3/Dockerfile
+++ b/tier3/Dockerfile
@@ -36,3 +36,4 @@ RUN (cd /opt && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ENV PATH="/opt/tprolog:/opt/groovy/bin:/opt/kotlin/bin:${PATH}:/opt/swift/usr/bin:/opt/zig:/opt/lean/bin"
+ENV LEAN_SYSROOT="/opt/lean"


### PR DESCRIPTION
Analysis:

The recent Lean 4 runner test failure reads like this:

```
Testing LEAN4:  Failed self-test
  Attempted:
    lean: /opt/lean/bin/lean
  Errors:
    Traceback (most recent call last):
      File "/judge/dmoj/executors/base_executor.py", line 343, in run_self_test
        executor = cls(cls.test_name, utf8bytes(cls.test_program))
      File "/judge/dmoj/executors/compiled_executor.py", line 66, in __call__
        obj.compile()
        ~~~~~~~~~~~^^
      File "/judge/dmoj/executors/LEAN4.py", line 26, in compile
        out2 = self.get_compile_output(proc2)
      File "/judge/dmoj/executors/compiled_executor.py", line 210, in get_compile_output
        self.handle_compile_error(output)
        ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
      File "/judge/dmoj/executors/compiled_executor.py", line 221, in handle_compile_error
        raise CompileError(output)
    dmoj.error.CompileError: uncaught exception: failed to locate application
```

The exact error message appears at https://github.com/leanprover/lean4/blob/945e78b86645b179655123cd2fdba83d89d28d07/src/runtime/io.cpp#L1414 and nowhere else. The executable for `proc2` is `leanc`, whose source code is `Leanc.lean`. The only possible execution path that leads to such failure seems to be `Leanc.lean` calling `IO.appDir` in

```
  let root ← match (← IO.getEnv "LEAN_SYSROOT") with
    | some root => pure <| System.FilePath.mk root
    | none      => pure <| (← IO.appDir).parent.get!
```

which calls `IO.appPath`, which is a wrapper for the CPP function.

This PR adds `LEAN_SYSROOT = "/opt/lean"` to avoid the branch that calls `IO.appDir`.

---

Second error:

```
libc++abi: terminating due to uncaught exception of type lean::exception: failed to create thread
Testing LEAN4:  Failed self-test
  Attempted:
    lean: /opt/lean/bin/lean
  Errors:
    Got unexpected stdout output:
```

This seems to come from the change in Lean 4 making `main` to run in a thread. This can be disabled with `LEAN_MAIN_USE_THREAD=0`.