### PR TITLE
tier1: Fix `$PATH` variable

### DIFF
--- a/tier1/Dockerfile
+++ b/tier1/Dockerfile
@@ -16,4 +16,5 @@ RUN echo deb http://deb.debian.org/debian/ bullseye main > /etc/apt/sources.list
     rm -f /opt/pypy3/bin/python* && \
     useradd -m judge
 
+ENV PATH="/opt/pypy3/bin:${PATH}"
 ENTRYPOINT ["/usr/bin/tini", "/code/run"]

--- a/tier2/Dockerfile
+++ b/tier2/Dockerfile
@@ -56,4 +56,4 @@ RUN apt-get update && \
         rm -f *.deb) && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-ENV PATH="/opt/dlang/linux/bin64:/home/judge/.cargo/bin:/opt/pypy2/bin:/opt/pypy3/bin:/opt/scala/bin:/opt/dart-sdk/bin:${PATH}"
+ENV PATH="/opt/dlang/linux/bin64:/home/judge/.cargo/bin:/opt/pypy2/bin:/opt/scala/bin:/opt/dart-sdk/bin:${PATH}"


### PR DESCRIPTION
Forgot to set this correctly in a4f1367, so PYPY3 doesn't actually work on tier1 :(